### PR TITLE
Fix inline keyboard not included when copying content

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -100,10 +100,8 @@ async def receive_content(message: types.Message, state: FSMContext):
         ]
     )
 
-    mod_message = await bot.copy_message(
+    mod_message = await message.send_copy(
         MOD_CHAT_ID,
-        message.chat.id,
-        message.message_id,
         reply_markup=kb,
     )
 


### PR DESCRIPTION
## Summary
- ensure `receive_content` attaches inline buttons using `message.send_copy`

## Testing
- `python -m py_compile bot.py`
- `python bot.py --help` *(fails: TokenValidationError)*

------
https://chatgpt.com/codex/tasks/task_e_68816bffd9dc8330b223454ddab0fe43