### PR TITLE
Add suggest content button to start menu

### DIFF
--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -1,11 +1,21 @@
 from aiogram import types, Router
 from aiogram.filters import CommandStart
+from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
+
+from .suggest import SUGGEST_BUTTON
 
 router = Router()
+
+
+menu_kb = ReplyKeyboardMarkup(
+    keyboard=[[KeyboardButton(text=SUGGEST_BUTTON)]],
+    resize_keyboard=True,
+)
 
 
 @router.message(CommandStart())
 async def handle_start(message: types.Message):
     await message.answer(
-        "Здравствуйте! Отправьте мне сообщение, и оно будет переслано модераторам."
+        "Здравствуйте! Отправьте мне сообщение, и оно будет переслано модераторам.",
+        reply_markup=menu_kb,
     )

--- a/app/handlers/suggest.py
+++ b/app/handlers/suggest.py
@@ -10,6 +10,8 @@ from app.config import Config
 
 router = Router()
 
+SUGGEST_BUTTON = "\u2709\ufe0f Предложить контент"
+
 
 class Suggest(StatesGroup):
     waiting_for_content = State()
@@ -26,6 +28,7 @@ def setup(config: Config):
 
 
 @router.message(Command("suggest"))
+@router.message(F.text == SUGGEST_BUTTON)
 async def cmd_suggest(message: types.Message, state: FSMContext):
     await state.set_state(Suggest.waiting_for_content)
     await message.answer(


### PR DESCRIPTION
## Summary
- show a reply keyboard when the user sends `/start`
- add "✉️ Предложить контент" button for suggesting content
- handle messages with the button text in the suggest handler

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68816fe17f24833094d5f95f178f4d00