### PR TITLE
Implement moderation database for banned words

### DIFF
--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -7,3 +7,8 @@ from .database import (
     init_tournament_db,
     get_tournament_ratings,
 )
+from .moderation import (
+    init_moderation_db,
+    add_banned_word,
+    add_banned_link,
+)

--- a/app/utils/moderation.py
+++ b/app/utils/moderation.py
@@ -1,0 +1,68 @@
+import sqlite3
+from pathlib import Path
+
+MOD_DB_PATH = Path(__file__).resolve().parent.parent / "moderation.db"
+
+
+def init_moderation_db() -> None:
+    """Create tables for banned words and links."""
+    with sqlite3.connect(MOD_DB_PATH) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS banned_words(
+                word TEXT PRIMARY KEY
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS banned_links(
+                link TEXT PRIMARY KEY
+            )
+            """
+        )
+        cur = conn.execute("SELECT COUNT(*) FROM banned_words")
+        if cur.fetchone()[0] == 0:
+            conn.executemany(
+                "INSERT INTO banned_words(word) VALUES(?)",
+                [
+                    ("spam",),
+                    ("junk",),
+                    ("badword",),
+                    ("хуй",),
+                    ("пизда",),
+                    ("блять",),
+                    ("сука",),
+                ],
+            )
+        conn.commit()
+
+
+def get_banned_words() -> set[str]:
+    with sqlite3.connect(MOD_DB_PATH) as conn:
+        cur = conn.execute("SELECT word FROM banned_words")
+        return {row[0].lower() for row in cur.fetchall()}
+
+
+def get_banned_links() -> set[str]:
+    with sqlite3.connect(MOD_DB_PATH) as conn:
+        cur = conn.execute("SELECT link FROM banned_links")
+        return {row[0].lower() for row in cur.fetchall()}
+
+
+def add_banned_word(word: str) -> None:
+    with sqlite3.connect(MOD_DB_PATH) as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO banned_words(word) VALUES(?)",
+            (word.lower(),),
+        )
+        conn.commit()
+
+
+def add_banned_link(link: str) -> None:
+    with sqlite3.connect(MOD_DB_PATH) as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO banned_links(link) VALUES(?)",
+            (link.lower(),),
+        )
+        conn.commit()

--- a/app/utils/spam.py
+++ b/app/utils/spam.py
@@ -1,22 +1,22 @@
 from datetime import datetime
 import time
 
+from .moderation import get_banned_words, get_banned_links
+
 # Maximum number of messages a user can send per day
 # Includes proposals, feedback and any other text input
 MAX_MESSAGES_PER_DAY = 10
 MIN_INTERVAL_SEC = 3
 
 user_stats: dict[int, dict] = {}
-# Basic set of banned words for profanity filtering
-banned_words = {
-    "spam",
-    "junk",
-    "badword",
-    "хуй",
-    "пизда",
-    "блять",
-    "сука",
-}
+
+
+def _load_banned_words() -> set[str]:
+    return get_banned_words()
+
+
+def _load_banned_links() -> set[str]:
+    return get_banned_links()
 
 
 def check_message_allowed(user_id: int, text: str) -> tuple[bool, str | None]:
@@ -36,9 +36,14 @@ def check_message_allowed(user_id: int, text: str) -> tuple[bool, str | None]:
         return False, "Превышен лимит сообщений на сегодня."
 
     text_lower = (text or "").lower()
-    for word in banned_words:
+
+    for word in _load_banned_words():
         if word in text_lower:
             return False, "Сообщение содержит запрещенные слова."
+
+    for link in _load_banned_links():
+        if link in text_lower:
+            return False, "Сообщение содержит запрещенные ссылки."
 
     data["count"] += 1
     data["last_time"] = now

--- a/bot.py
+++ b/bot.py
@@ -5,7 +5,11 @@ from aiogram import Bot, Dispatcher
 
 from app.config import load_config, Config
 from app.handlers import register_handlers
-from app.utils import init_db, init_tournament_db
+from app.utils import (
+    init_db,
+    init_tournament_db,
+    init_moderation_db,
+)
 
 logging.basicConfig(level=logging.INFO)
 
@@ -14,6 +18,7 @@ async def main() -> None:
     config: Config = load_config()
     init_db()
     init_tournament_db()
+    init_moderation_db()
     bot = Bot(config.bot_token)
     dp = Dispatcher()
 


### PR DESCRIPTION
## Summary
- introduce `moderation.db` and helper module for banned words/links
- load banned words and links dynamically in spam checker
- initialize moderation database at startup

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688219833ea88330b4f48d4b67a73368