### PR TITLE
Add warning system and moderation commands

### DIFF
--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -13,4 +13,13 @@ from .moderation import (
     init_moderation_db,
     add_banned_word,
     add_banned_link,
+    add_warning,
+    get_warnings,
+    clear_warnings,
+    mute_user,
+    unmute_user,
+    is_muted,
+    ban_user,
+    unban_user,
+    is_banned,
 )


### PR DESCRIPTION
## Summary
- extend moderation DB to track warnings, mutes and bans
- expose moderation helpers through `app.utils`
- enhance forum moderation with automatic warnings and 24h mutes
- add moderation commands for manual banning, muting and clearing warnings

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688234f0a9648330aa388f9243140148