### PR TITLE
Add admin menus and tournament management

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -8,3 +8,8 @@ FEEDBACK_BUTTON = "\U0001F4AC Обратная связь"
 PROPOSAL_BUTTON = "Предложения"
 QUESTION_BUTTON = "Вопрос"
 COMPLAINT_BUTTON = "Жалоба"
+
+CREATE_TOURNAMENT_BUTTON = "Создать турнир"
+MUTED_LIST_BUTTON = "Список мута"
+BANNED_LIST_BUTTON = "Список забаненных"
+ASSIGN_ROLE_BUTTON = "Назначить админа/модератора"

--- a/app/handlers/__init__.py
+++ b/app/handlers/__init__.py
@@ -5,6 +5,7 @@ from . import start, suggest, misc, profile, tournaments, feedback, admin, forum
 
 
 def register_handlers(dp: Dispatcher, config: Config) -> None:
+    start.setup(config)
     dp.include_router(start.router)
     suggest.setup(config)
     dp.include_router(suggest.router)

--- a/app/handlers/admin.py
+++ b/app/handlers/admin.py
@@ -1,11 +1,37 @@
 from aiogram import Router, types, F
 from aiogram.filters import Command
+from aiogram.types import ReplyKeyboardMarkup, KeyboardButton, InlineKeyboardMarkup, InlineKeyboardButton
+from aiogram.fsm.state import State, StatesGroup
+from aiogram.fsm.context import FSMContext
 
 from app.config import Config
-from app.utils import get_all_user_ids
+from app.constants import (
+    CREATE_TOURNAMENT_BUTTON,
+    MUTED_LIST_BUTTON,
+    BANNED_LIST_BUTTON,
+    ASSIGN_ROLE_BUTTON,
+)
+from app.utils import (
+    get_all_user_ids,
+    add_tournament,
+    get_all_mutes,
+    get_all_bans,
+    unmute_user,
+    unban_user,
+    add_admin,
+    add_moderator,
+    get_admins,
+    get_moderators,
+)
 
 router = Router()
 _config: Config
+
+
+class TournamentCreate(StatesGroup):
+    waiting_game = State()
+    waiting_type = State()
+    waiting_date = State()
 
 
 def setup(config: Config) -> None:
@@ -30,4 +56,127 @@ async def broadcast(message: types.Message) -> None:
         except Exception:
             pass
     await message.answer(f"Рассылка отправлена {count} пользователям.")
+
+
+def _is_admin(user_id: int) -> bool:
+    return user_id == _config.admin_id or user_id in get_admins()
+
+
+def _is_staff(user_id: int) -> bool:
+    return _is_admin(user_id) or user_id in get_moderators()
+
+
+@router.message(F.text == CREATE_TOURNAMENT_BUTTON)
+async def create_tournament_start(message: types.Message, state: FSMContext) -> None:
+    if not _is_admin(message.from_user.id):
+        return
+    await state.set_state(TournamentCreate.waiting_game)
+    kb = ReplyKeyboardMarkup(
+        keyboard=[[KeyboardButton(text="CS2")], [KeyboardButton(text="Dota 2")], [KeyboardButton(text="Valorant")]],
+        resize_keyboard=True,
+    )
+    await message.answer("Выберите игру", reply_markup=kb)
+
+
+@router.message(TournamentCreate.waiting_game)
+async def choose_type(message: types.Message, state: FSMContext) -> None:
+    await state.update_data(game=message.text)
+    await state.set_state(TournamentCreate.waiting_type)
+    kb = ReplyKeyboardMarkup(
+        keyboard=[[KeyboardButton(text="1 vs 1")], [KeyboardButton(text="2 vs 2")], [KeyboardButton(text="5 vs 5")]],
+        resize_keyboard=True,
+    )
+    await message.answer("Выберите формат", reply_markup=kb)
+
+
+@router.message(TournamentCreate.waiting_type)
+async def choose_date(message: types.Message, state: FSMContext) -> None:
+    await state.update_data(type=message.text)
+    await state.set_state(TournamentCreate.waiting_date)
+    await message.answer("Введите дату турнира (например, 01.01.2024)")
+
+
+@router.message(TournamentCreate.waiting_date)
+async def save_tournament(message: types.Message, state: FSMContext) -> None:
+    data = await state.get_data()
+    add_tournament(data.get("game"), data.get("type"), message.text)
+    await message.answer("Турнир создан")
+    await state.clear()
+
+
+@router.message(F.text == MUTED_LIST_BUTTON)
+async def list_mutes(message: types.Message) -> None:
+    if not _is_staff(message.from_user.id):
+        return
+    entries = get_all_mutes()
+    if not entries:
+        await message.answer("Список мута пуст")
+        return
+    for user_id, _ in entries:
+        kb = InlineKeyboardMarkup(
+            inline_keyboard=[[InlineKeyboardButton(text="Размутить", callback_data=f"unmute:{user_id}")]]
+        )
+        await message.answer(str(user_id), reply_markup=kb)
+
+
+@router.message(F.text == BANNED_LIST_BUTTON)
+async def list_bans(message: types.Message) -> None:
+    if not _is_staff(message.from_user.id):
+        return
+    entries = get_all_bans()
+    if not entries:
+        await message.answer("Список банов пуст")
+        return
+    for user_id in entries:
+        kb = InlineKeyboardMarkup(
+            inline_keyboard=[[InlineKeyboardButton(text="Разбанить", callback_data=f"unban:{user_id}")]]
+        )
+        await message.answer(str(user_id), reply_markup=kb)
+
+
+@router.callback_query(F.data.startswith("unmute:"))
+async def cb_unmute(callback: types.CallbackQuery) -> None:
+    user_id = int(callback.data.split(":", 1)[1])
+    unmute_user(user_id)
+    await callback.answer("Пользователь размучен")
+    await callback.message.edit_text("Размучен")
+
+
+@router.callback_query(F.data.startswith("unban:"))
+async def cb_unban(callback: types.CallbackQuery) -> None:
+    user_id = int(callback.data.split(":", 1)[1])
+    unban_user(user_id)
+    await callback.answer("Пользователь разбанен")
+    await callback.message.edit_text("Разбанен")
+
+
+@router.message(Command("promote"))
+async def promote_user(message: types.Message) -> None:
+    if message.from_user.id != _config.admin_id:
+        return
+    parts = message.text.split()
+    if len(parts) != 3:
+        await message.reply("Usage: /promote <user_id> <admin|mod>")
+        return
+    try:
+        user_id = int(parts[1])
+    except ValueError:
+        await message.reply("Invalid user id")
+        return
+    role = parts[2].lower()
+    if role == "admin":
+        add_admin(user_id)
+    elif role == "mod":
+        add_moderator(user_id)
+    else:
+        await message.reply("Role must be admin or mod")
+        return
+    await message.reply("Пользователь назначен")
+
+
+@router.message(F.text == ASSIGN_ROLE_BUTTON)
+async def assign_help(message: types.Message) -> None:
+    if message.from_user.id != _config.admin_id:
+        return
+    await message.answer("Используйте команду /promote <user_id> <admin|mod>")
 

--- a/app/handlers/tournaments.py
+++ b/app/handlers/tournaments.py
@@ -2,7 +2,7 @@ from aiogram import Router, types, F
 from aiogram.filters import Command
 from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
 
-from app.utils import get_tournament_ratings
+from app.utils import get_tournament_ratings, get_tournaments
 from app.constants import (
     TOURNAMENTS_BUTTON,
     JOIN_BUTTON,
@@ -40,13 +40,14 @@ async def tournaments_back(message: types.Message) -> None:
 
 @router.message(F.text == JOIN_BUTTON)
 async def show_tournaments(message: types.Message) -> None:
-    text = (
-        "Актуальные турниры:\n"
-        "- CS2\n"
-        "- Dota 2\n"
-        "- Valorant"
-    )
-    await message.answer(text)
+    tournaments = get_tournaments()
+    if not tournaments:
+        await message.answer("Турниры не запланированы")
+        return
+    lines = ["Актуальные турниры:"]
+    for tid, game, type_, date in tournaments:
+        lines.append(f"{tid}. {game} {type_} — {date}")
+    await message.answer("\n".join(lines))
 
 
 @router.message(F.text == RATING_BUTTON)

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -8,6 +8,9 @@ from .database import (
     get_all_user_ids,
     init_tournament_db,
     get_tournament_ratings,
+    init_tournament_info_db,
+    add_tournament,
+    get_tournaments,
 )
 from .moderation import (
     init_moderation_db,
@@ -22,4 +25,12 @@ from .moderation import (
     ban_user,
     unban_user,
     is_banned,
+    get_all_mutes,
+    get_all_bans,
+    add_admin,
+    remove_admin,
+    get_admins,
+    add_moderator,
+    remove_moderator,
+    get_moderators,
 )

--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -129,3 +129,37 @@ def get_tournament_ratings(limit: int = 10) -> list[tuple]:
         name = user.get("name") if user else f"User {row['user_id']}"
         results.append((idx, name, row["score"]))
     return results
+
+
+TOURNAMENT_INFO_DB_PATH = Path(__file__).resolve().parent.parent / "tournaments_info.db"
+
+
+def init_tournament_info_db() -> None:
+    """Create table for tournament info."""
+    with sqlite3.connect(TOURNAMENT_INFO_DB_PATH) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS tournaments (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                game TEXT,
+                type TEXT,
+                date TEXT
+            )
+            """
+        )
+        conn.commit()
+
+
+def add_tournament(game: str, type_: str, date: str) -> None:
+    with sqlite3.connect(TOURNAMENT_INFO_DB_PATH) as conn:
+        conn.execute(
+            "INSERT INTO tournaments(game, type, date) VALUES(?,?,?)",
+            (game, type_, date),
+        )
+        conn.commit()
+
+
+def get_tournaments() -> list[tuple]:
+    with sqlite3.connect(TOURNAMENT_INFO_DB_PATH) as conn:
+        cur = conn.execute("SELECT id, game, type, date FROM tournaments ORDER BY id DESC")
+        return cur.fetchall()

--- a/app/utils/moderation.py
+++ b/app/utils/moderation.py
@@ -59,6 +59,20 @@ def init_moderation_db() -> None:
             )
             """
         )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS admins(
+                user_id INTEGER PRIMARY KEY
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS moderators(
+                user_id INTEGER PRIMARY KEY
+            )
+            """
+        )
         conn.commit()
 
 
@@ -180,3 +194,57 @@ def is_banned(user_id: int) -> bool:
     with sqlite3.connect(MOD_DB_PATH) as conn:
         cur = conn.execute("SELECT 1 FROM bans WHERE user_id=?", (user_id,))
         return cur.fetchone() is not None
+
+
+def get_all_mutes() -> list[tuple[int, int]]:
+    with sqlite3.connect(MOD_DB_PATH) as conn:
+        cur = conn.execute("SELECT user_id, until FROM mutes")
+        return cur.fetchall()
+
+
+def get_all_bans() -> list[int]:
+    with sqlite3.connect(MOD_DB_PATH) as conn:
+        cur = conn.execute("SELECT user_id FROM bans")
+        return [row[0] for row in cur.fetchall()]
+
+
+def add_admin(user_id: int) -> None:
+    with sqlite3.connect(MOD_DB_PATH) as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO admins(user_id) VALUES(?)",
+            (user_id,),
+        )
+        conn.commit()
+
+
+def remove_admin(user_id: int) -> None:
+    with sqlite3.connect(MOD_DB_PATH) as conn:
+        conn.execute("DELETE FROM admins WHERE user_id=?", (user_id,))
+        conn.commit()
+
+
+def get_admins() -> list[int]:
+    with sqlite3.connect(MOD_DB_PATH) as conn:
+        cur = conn.execute("SELECT user_id FROM admins")
+        return [row[0] for row in cur.fetchall()]
+
+
+def add_moderator(user_id: int) -> None:
+    with sqlite3.connect(MOD_DB_PATH) as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO moderators(user_id) VALUES(?)",
+            (user_id,),
+        )
+        conn.commit()
+
+
+def remove_moderator(user_id: int) -> None:
+    with sqlite3.connect(MOD_DB_PATH) as conn:
+        conn.execute("DELETE FROM moderators WHERE user_id=?", (user_id,))
+        conn.commit()
+
+
+def get_moderators() -> list[int]:
+    with sqlite3.connect(MOD_DB_PATH) as conn:
+        cur = conn.execute("SELECT user_id FROM moderators")
+        return [row[0] for row in cur.fetchall()]

--- a/bot.py
+++ b/bot.py
@@ -8,6 +8,7 @@ from app.handlers import register_handlers
 from app.utils import (
     init_db,
     init_tournament_db,
+    init_tournament_info_db,
     init_moderation_db,
 )
 
@@ -18,6 +19,7 @@ async def main() -> None:
     config: Config = load_config()
     init_db()
     init_tournament_db()
+    init_tournament_info_db()
     init_moderation_db()
     bot = Bot(config.bot_token)
     dp = Dispatcher()


### PR DESCRIPTION
## Summary
- extend constants with admin menu options
- show role-specific menus in `/start`
- implement admin tools for tournament creation and moderation
- store tournaments and staff roles in database
- display tournaments from DB

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688270fd8e448330a1073dd425607107