### PR TITLE
Add prize fund input when creating tournament

### DIFF
--- a/app/handlers/admin.py
+++ b/app/handlers/admin.py
@@ -32,6 +32,7 @@ class TournamentCreate(StatesGroup):
     waiting_game = State()
     waiting_type = State()
     waiting_date = State()
+    waiting_prize = State()
 
 
 def setup(config: Config) -> None:
@@ -97,9 +98,21 @@ async def choose_date(message: types.Message, state: FSMContext) -> None:
 
 
 @router.message(TournamentCreate.waiting_date)
+async def ask_prize(message: types.Message, state: FSMContext) -> None:
+    await state.update_data(date=message.text)
+    await state.set_state(TournamentCreate.waiting_prize)
+    await message.answer("Введите призовой фонд")
+
+
+@router.message(TournamentCreate.waiting_prize)
 async def save_tournament(message: types.Message, state: FSMContext) -> None:
     data = await state.get_data()
-    add_tournament(data.get("game"), data.get("type"), message.text)
+    add_tournament(
+        data.get("game"),
+        data.get("type"),
+        data.get("date"),
+        message.text,
+    )
     await message.answer("Турнир создан")
     await state.clear()
 

--- a/app/handlers/tournaments.py
+++ b/app/handlers/tournaments.py
@@ -45,8 +45,8 @@ async def show_tournaments(message: types.Message) -> None:
         await message.answer("Турниры не запланированы")
         return
     lines = ["Актуальные турниры:"]
-    for tid, game, type_, date in tournaments:
-        lines.append(f"{tid}. {game} {type_} — {date}")
+    for tid, game, type_, date, prize in tournaments:
+        lines.append(f"{tid}. {game} {type_} — {date}, призовой фонд: {prize}")
     await message.answer("\n".join(lines))
 
 

--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -143,23 +143,31 @@ def init_tournament_info_db() -> None:
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 game TEXT,
                 type TEXT,
-                date TEXT
+                date TEXT,
+                prize TEXT
             )
             """
         )
+        # try to add missing column "prize" for older versions
+        try:
+            conn.execute("ALTER TABLE tournaments ADD COLUMN prize TEXT")
+        except sqlite3.OperationalError:
+            pass
         conn.commit()
 
 
-def add_tournament(game: str, type_: str, date: str) -> None:
+def add_tournament(game: str, type_: str, date: str, prize: str) -> None:
     with sqlite3.connect(TOURNAMENT_INFO_DB_PATH) as conn:
         conn.execute(
-            "INSERT INTO tournaments(game, type, date) VALUES(?,?,?)",
-            (game, type_, date),
+            "INSERT INTO tournaments(game, type, date, prize) VALUES(?,?,?,?)",
+            (game, type_, date, prize),
         )
         conn.commit()
 
 
 def get_tournaments() -> list[tuple]:
     with sqlite3.connect(TOURNAMENT_INFO_DB_PATH) as conn:
-        cur = conn.execute("SELECT id, game, type, date FROM tournaments ORDER BY id DESC")
+        cur = conn.execute(
+            "SELECT id, game, type, date, prize FROM tournaments ORDER BY id DESC"
+        )
         return cur.fetchall()


### PR DESCRIPTION
## Summary
- request prize fund when creating tournaments
- store prize fund in tournaments database
- show prize fund in tournament list

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688273dbff908330949c1dba7a11df1c