### PR TITLE
Ensure admin menu persists and improve participant list

### DIFF
--- a/app/handlers/admin.py
+++ b/app/handlers/admin.py
@@ -31,6 +31,7 @@ from app.utils import (
     add_moderator,
     get_admins,
     get_moderators,
+    get_user_stats,
 )
 
 router = Router()
@@ -119,10 +120,8 @@ def _is_staff(user_id: int) -> bool:
 
 
 def _menu_kb(user_id: int) -> ReplyKeyboardMarkup:
-    """Return appropriate admin menu keyboard."""
-    if user_id == _config.admin_id:
-        return start.main_admin_kb
-    return start.admin_kb
+    """Return menu keyboard for admin or moderator."""
+    return start.get_menu_kb(user_id)
 
 
 @router.message(
@@ -366,7 +365,9 @@ async def cb_list_participants(callback: types.CallbackQuery) -> None:
                 [InlineKeyboardButton(text="Исключить", callback_data=f"kick_part:{tid}:{user_id}")]
             ]
         )
-        await callback.message.answer(f"{nickname} ({age}) — {user_id}", reply_markup=kb)
+        stats = get_user_stats(user_id)
+        username = f"@{stats.get('username')}" if stats and stats.get('username') else "нет"
+        await callback.message.answer(f"{nickname} ({age}) — {username}", reply_markup=kb)
 
 
 @router.callback_query(F.data.startswith("kick_part:"))

--- a/app/handlers/feedback.py
+++ b/app/handlers/feedback.py
@@ -61,7 +61,7 @@ async def feedback_menu(message: types.Message) -> None:
 @router.message(F.text == BACK_BUTTON)
 async def feedback_back(message: types.Message, state: FSMContext) -> None:
     await state.clear()
-    await message.answer("Главное меню", reply_markup=start.menu_kb)
+    await message.answer("Главное меню", reply_markup=start.get_menu_kb(message.from_user.id))
 
 
 @router.message(F.text == PROPOSAL_BUTTON)
@@ -73,7 +73,7 @@ async def ask_proposal(message: types.Message, state: FSMContext) -> None:
 @router.message(FeedbackState.waiting_proposal, F.text == BACK_BUTTON)
 async def cancel_proposal(message: types.Message, state: FSMContext) -> None:
     await state.clear()
-    await message.answer("Главное меню", reply_markup=start.menu_kb)
+    await message.answer("Главное меню", reply_markup=start.get_menu_kb(message.from_user.id))
 
 
 @router.message(FeedbackState.waiting_proposal)
@@ -89,7 +89,7 @@ async def handle_proposal(message: types.Message, state: FSMContext) -> None:
     entries[mod_msg.message_id] = message.chat.id
     await message.answer(
         "Отправили твоё предложение, спасибо за активность!",
-        reply_markup=start.menu_kb,
+        reply_markup=start.get_menu_kb(message.from_user.id),
     )
     await state.clear()
 
@@ -103,7 +103,7 @@ async def ask_question(message: types.Message, state: FSMContext) -> None:
 @router.message(FeedbackState.waiting_question, F.text == BACK_BUTTON)
 async def cancel_question(message: types.Message, state: FSMContext) -> None:
     await state.clear()
-    await message.answer("Главное меню", reply_markup=start.menu_kb)
+    await message.answer("Главное меню", reply_markup=start.get_menu_kb(message.from_user.id))
 
 
 @router.message(FeedbackState.waiting_question)
@@ -119,7 +119,7 @@ async def handle_question(message: types.Message, state: FSMContext) -> None:
     entries[mod_msg.message_id] = message.chat.id
     await message.answer(
         "Спасибо за вопрос, ответим в скором времени!",
-        reply_markup=start.menu_kb,
+        reply_markup=start.get_menu_kb(message.from_user.id),
     )
     await state.clear()
 
@@ -136,7 +136,7 @@ async def ask_complaint(message: types.Message, state: FSMContext) -> None:
 @router.message(FeedbackState.waiting_complaint, F.text == BACK_BUTTON)
 async def cancel_complaint(message: types.Message, state: FSMContext) -> None:
     await state.clear()
-    await message.answer("Главное меню", reply_markup=start.menu_kb)
+    await message.answer("Главное меню", reply_markup=start.get_menu_kb(message.from_user.id))
 
 
 @router.message(FeedbackState.waiting_complaint)
@@ -150,7 +150,7 @@ async def handle_complaint(message: types.Message, state: FSMContext) -> None:
         f"[Жалоба]\nОт {message.from_user.full_name} ({message.from_user.id})\n{message.text}",
     )
     entries[mod_msg.message_id] = message.chat.id
-    await message.answer("Всё решим, не волнуйся!", reply_markup=start.menu_kb)
+    await message.answer("Всё решим, не волнуйся!", reply_markup=start.get_menu_kb(message.from_user.id))
     await state.clear()
 
 

--- a/app/handlers/profile.py
+++ b/app/handlers/profile.py
@@ -35,4 +35,4 @@ async def handle_profile(message: types.Message) -> None:
         f"Предупреждений: {warnings}\n"
         f"Ранг: {rank}"
     )
-    await message.answer(text, reply_markup=start.menu_kb)
+    await message.answer(text, reply_markup=start.get_menu_kb(message.from_user.id))

--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -21,6 +21,17 @@ router = Router()
 _config: Config
 
 
+def get_menu_kb(user_id: int) -> ReplyKeyboardMarkup:
+    """Return menu keyboard appropriate for the user."""
+    if user_id == _config.admin_id:
+        return main_admin_kb
+    if user_id in get_admins():
+        return admin_kb
+    if user_id in get_moderators():
+        return moderator_kb
+    return menu_kb
+
+
 def setup(config: Config) -> None:
     global _config
     _config = config
@@ -69,17 +80,14 @@ main_admin_kb = ReplyKeyboardMarkup(
 async def handle_start(message: types.Message):
     add_user(message.from_user)
     user_id = message.from_user.id
-    if user_id == _config.admin_id:
-        kb = main_admin_kb
+    kb = get_menu_kb(user_id)
+    if kb is main_admin_kb:
         text = "\U0001F4DD Главное меню администратора"
-    elif user_id in get_admins():
-        kb = admin_kb
+    elif kb is admin_kb:
         text = "\U0001F4DD Меню администратора"
-    elif user_id in get_moderators():
-        kb = moderator_kb
+    elif kb is moderator_kb:
         text = "\U0001F4DD Меню модератора"
     else:
-        kb = menu_kb
         text = (
             "\U0001F44B Здравствуйте! Нажмите \"Предложить контент\", чтобы отправить материал на модерацию, \"Профиль\" для просмотра статистики или \"Турниры\" для участия."
         )

--- a/app/handlers/suggest.py
+++ b/app/handlers/suggest.py
@@ -52,7 +52,7 @@ async def cmd_suggest(message: types.Message, state: FSMContext):
 @router.message(Suggest.waiting_for_content, F.text == BACK_BUTTON)
 async def cancel_suggest(message: types.Message, state: FSMContext) -> None:
     await state.clear()
-    await message.answer("Главное меню", reply_markup=start.menu_kb)
+    await message.answer("Главное меню", reply_markup=start.get_menu_kb(message.from_user.id))
 
 
 @router.message(Suggest.waiting_for_content)
@@ -91,7 +91,7 @@ async def receive_content(message: types.Message, state: FSMContext):
 
     await message.answer(
         "Контент отправлен на модерацию.",
-        reply_markup=start.menu_kb,
+        reply_markup=start.get_menu_kb(message.from_user.id),
     )
     await state.clear()
 

--- a/app/handlers/tournaments.py
+++ b/app/handlers/tournaments.py
@@ -58,7 +58,7 @@ async def tournaments_menu(message: types.Message) -> None:
 
 @router.message(F.text == BACK_BUTTON)
 async def tournaments_back(message: types.Message) -> None:
-    await message.answer("Главное меню", reply_markup=start.menu_kb)
+    await message.answer("Главное меню", reply_markup=start.get_menu_kb(message.from_user.id))
 
 
 @router.message(F.text == JOIN_BUTTON)
@@ -107,7 +107,7 @@ async def cb_join_tournament(callback: types.CallbackQuery, state: FSMContext) -
 @router.message(JoinState.waiting_age, F.text == BACK_BUTTON)
 async def cancel_join(message: types.Message, state: FSMContext) -> None:
     await state.clear()
-    await message.answer("Главное меню", reply_markup=start.menu_kb)
+    await message.answer("Главное меню", reply_markup=start.get_menu_kb(message.from_user.id))
 
 
 @router.message(JoinState.waiting_nick)
@@ -132,7 +132,7 @@ async def save_participant(message: types.Message, state: FSMContext) -> None:
         age,
     )
     if added:
-        await message.answer("Вы записаны на турнир!", reply_markup=start.menu_kb)
+        await message.answer("Вы записаны на турнир!", reply_markup=start.get_menu_kb(message.from_user.id))
     else:
-        await message.answer("Вы уже записаны на этот турнир.", reply_markup=start.menu_kb)
+        await message.answer("Вы уже записаны на этот турнир.", reply_markup=start.get_menu_kb(message.from_user.id))
     await state.clear()


### PR DESCRIPTION
## Summary
- add helper to choose menu keyboard based on user role
- use new helper across handlers so admins keep admin menu
- show usernames instead of IDs in tournament participant list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68882a705df88330b4fd7f7dfc0a84cf