### PR TITLE
Add admin user management features

### DIFF
--- a/app/handlers/profile.py
+++ b/app/handlers/profile.py
@@ -26,6 +26,7 @@ async def handle_profile(message: types.Message) -> None:
     add_user(message.from_user)
     stats = get_user_stats(message.from_user.id) or {}
     xp = stats.get("xp", 0)
+    title = stats.get("title") or "-"
     warnings = get_warnings(message.from_user.id)
     rank = get_rank(xp)
 
@@ -33,6 +34,7 @@ async def handle_profile(message: types.Message) -> None:
         f"Username: @{message.from_user.username or 'нет'}\n"
         f"XP: {xp}\n"
         f"Предупреждений: {warnings}\n"
-        f"Ранг: {rank}"
+        f"Ранг: {rank}\n"
+        f"Титул: {title}"
     )
     await message.answer(text, reply_markup=start.get_menu_kb(message.from_user.id))

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -4,6 +4,8 @@ from .database import (
     increment_submission,
     record_result,
     get_user_stats,
+    get_user_by_username,
+    set_user_title,
     add_xp,
     get_all_user_ids,
     init_tournament_db,


### PR DESCRIPTION
## Summary
- allow titles for users and show in /profile
- support permanent mutes and bans with expiry in DB
- implement /user admin command to edit user profile
- add helper functions for searching users and setting titles

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68882cacade08330927e6c71f0773fca