### PR TITLE
Implement chat cleanup

### DIFF
--- a/app/handlers/feedback.py
+++ b/app/handlers/feedback.py
@@ -14,6 +14,7 @@ from app.constants import (
 from app.utils.spam import check_message_allowed
 from app.config import Config
 from . import start
+from app.utils import record_message, record_sent, cleanup
 
 router = Router()
 _config: Config
@@ -52,105 +53,141 @@ entries: dict[int, int] = {}
 @router.message(Command("feedback"))
 @router.message(F.text == FEEDBACK_BUTTON)
 async def feedback_menu(message: types.Message) -> None:
-    await message.answer(
+    record_message(message)
+    await cleanup(message.bot, message.chat.id)
+    sent = await message.answer(
         "\U0001F4AC Есть какие-то идеи по улучшению, жалоба или вопрос? Пиши!",
         reply_markup=feedback_kb,
     )
+    record_sent(sent)
 
 
 @router.message(F.text == BACK_BUTTON)
 async def feedback_back(message: types.Message, state: FSMContext) -> None:
+    record_message(message)
+    await cleanup(message.bot, message.chat.id)
     await state.clear()
-    await message.answer("Главное меню", reply_markup=start.get_menu_kb(message.from_user.id))
+    sent = await message.answer("Главное меню", reply_markup=start.get_menu_kb(message.from_user.id))
+    record_sent(sent)
 
 
 @router.message(F.text == PROPOSAL_BUTTON)
 async def ask_proposal(message: types.Message, state: FSMContext) -> None:
-    await message.answer("\U0001F4A1 Что хочешь предложить, приятель?", reply_markup=cancel_kb)
+    record_message(message)
+    await cleanup(message.bot, message.chat.id)
+    sent = await message.answer("\U0001F4A1 Что хочешь предложить, приятель?", reply_markup=cancel_kb)
+    record_sent(sent)
     await state.set_state(FeedbackState.waiting_proposal)
 
 
 @router.message(FeedbackState.waiting_proposal, F.text == BACK_BUTTON)
 async def cancel_proposal(message: types.Message, state: FSMContext) -> None:
+    record_message(message)
+    await cleanup(message.bot, message.chat.id)
     await state.clear()
-    await message.answer("Главное меню", reply_markup=start.get_menu_kb(message.from_user.id))
+    sent = await message.answer("Главное меню", reply_markup=start.get_menu_kb(message.from_user.id))
+    record_sent(sent)
 
 
 @router.message(FeedbackState.waiting_proposal)
 async def handle_proposal(message: types.Message, state: FSMContext) -> None:
+    record_message(message)
+    await cleanup(message.bot, message.chat.id)
     allowed, reason = check_message_allowed(message.from_user.id, message.text or "")
     if not allowed:
-        await message.answer(reason)
+        sent = await message.answer(reason)
+        record_sent(sent)
         return
     mod_msg = await message.bot.send_message(
         _config.feedback_chat_id,
         f"[Предложение]\nОт {message.from_user.full_name} ({message.from_user.id})\n{message.text}",
     )
     entries[mod_msg.message_id] = message.chat.id
-    await message.answer(
+    sent = await message.answer(
         "Отправили твоё предложение, спасибо за активность!",
         reply_markup=start.get_menu_kb(message.from_user.id),
     )
+    record_sent(sent)
     await state.clear()
 
 
 @router.message(F.text == QUESTION_BUTTON)
 async def ask_question(message: types.Message, state: FSMContext) -> None:
-    await message.answer("\u2753 Задай свой вопрос", reply_markup=cancel_kb)
+    record_message(message)
+    await cleanup(message.bot, message.chat.id)
+    sent = await message.answer("\u2753 Задай свой вопрос", reply_markup=cancel_kb)
+    record_sent(sent)
     await state.set_state(FeedbackState.waiting_question)
 
 
 @router.message(FeedbackState.waiting_question, F.text == BACK_BUTTON)
 async def cancel_question(message: types.Message, state: FSMContext) -> None:
+    record_message(message)
+    await cleanup(message.bot, message.chat.id)
     await state.clear()
-    await message.answer("Главное меню", reply_markup=start.get_menu_kb(message.from_user.id))
+    sent = await message.answer("Главное меню", reply_markup=start.get_menu_kb(message.from_user.id))
+    record_sent(sent)
 
 
 @router.message(FeedbackState.waiting_question)
 async def handle_question(message: types.Message, state: FSMContext) -> None:
+    record_message(message)
+    await cleanup(message.bot, message.chat.id)
     allowed, reason = check_message_allowed(message.from_user.id, message.text or "")
     if not allowed:
-        await message.answer(reason)
+        sent = await message.answer(reason)
+        record_sent(sent)
         return
     mod_msg = await message.bot.send_message(
         _config.feedback_chat_id,
         f"[Вопрос]\nОт {message.from_user.full_name} ({message.from_user.id})\n{message.text}",
     )
     entries[mod_msg.message_id] = message.chat.id
-    await message.answer(
+    sent = await message.answer(
         "Спасибо за вопрос, ответим в скором времени!",
         reply_markup=start.get_menu_kb(message.from_user.id),
     )
+    record_sent(sent)
     await state.clear()
 
 
 @router.message(F.text == COMPLAINT_BUTTON)
 async def ask_complaint(message: types.Message, state: FSMContext) -> None:
-    await message.answer(
+    record_message(message)
+    await cleanup(message.bot, message.chat.id)
+    sent = await message.answer(
         "\U0001F620 Воу воу, приятель, что не так? Расскажи подробнее",
         reply_markup=cancel_kb,
     )
+    record_sent(sent)
     await state.set_state(FeedbackState.waiting_complaint)
 
 
 @router.message(FeedbackState.waiting_complaint, F.text == BACK_BUTTON)
 async def cancel_complaint(message: types.Message, state: FSMContext) -> None:
+    record_message(message)
+    await cleanup(message.bot, message.chat.id)
     await state.clear()
-    await message.answer("Главное меню", reply_markup=start.get_menu_kb(message.from_user.id))
+    sent = await message.answer("Главное меню", reply_markup=start.get_menu_kb(message.from_user.id))
+    record_sent(sent)
 
 
 @router.message(FeedbackState.waiting_complaint)
 async def handle_complaint(message: types.Message, state: FSMContext) -> None:
+    record_message(message)
+    await cleanup(message.bot, message.chat.id)
     allowed, reason = check_message_allowed(message.from_user.id, message.text or "")
     if not allowed:
-        await message.answer(reason)
+        sent = await message.answer(reason)
+        record_sent(sent)
         return
     mod_msg = await message.bot.send_message(
         _config.feedback_chat_id,
         f"[Жалоба]\nОт {message.from_user.full_name} ({message.from_user.id})\n{message.text}",
     )
     entries[mod_msg.message_id] = message.chat.id
-    await message.answer("Всё решим, не волнуйся!", reply_markup=start.get_menu_kb(message.from_user.id))
+    sent = await message.answer("Всё решим, не волнуйся!", reply_markup=start.get_menu_kb(message.from_user.id))
+    record_sent(sent)
     await state.clear()
 
 

--- a/app/handlers/profile.py
+++ b/app/handlers/profile.py
@@ -1,7 +1,14 @@
 from aiogram import Router, types, F
 from aiogram.filters import Command
 
-from app.utils import add_user, get_user_stats, get_warnings
+from app.utils import (
+    add_user,
+    get_user_stats,
+    get_warnings,
+    record_message,
+    record_sent,
+    cleanup,
+)
 from app.constants import PROFILE_BUTTON
 from . import start
 
@@ -29,6 +36,8 @@ def get_rank(xp: int) -> str:
 @router.message(Command("profile"))
 @router.message(F.text == PROFILE_BUTTON)
 async def handle_profile(message: types.Message) -> None:
+    record_message(message)
+    await cleanup(message.bot, message.chat.id)
     add_user(message.from_user)
     stats = get_user_stats(message.from_user.id) or {}
     xp = stats.get("xp", 0)
@@ -43,4 +52,5 @@ async def handle_profile(message: types.Message) -> None:
         f"Ранг: {rank}\n"
         f"Титул: {title}"
     )
-    await message.answer(text, reply_markup=start.get_menu_kb(message.from_user.id))
+    sent = await message.answer(text, reply_markup=start.get_menu_kb(message.from_user.id))
+    record_sent(sent)

--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -14,7 +14,14 @@ from app.constants import (
     BANNED_LIST_BUTTON,
     ASSIGN_ROLE_BUTTON,
 )
-from app.utils import add_user, get_admins, get_moderators
+from app.utils import (
+    add_user,
+    get_admins,
+    get_moderators,
+    record_message,
+    record_sent,
+    cleanup,
+)
 from app.config import Config
 
 router = Router()
@@ -81,6 +88,8 @@ main_admin_kb = ReplyKeyboardMarkup(
 
 @router.message(CommandStart())
 async def handle_start(message: types.Message):
+    record_message(message)
+    await cleanup(message.bot, message.chat.id)
     add_user(message.from_user)
     user_id = message.from_user.id
     kb = get_menu_kb(user_id)
@@ -95,4 +104,5 @@ async def handle_start(message: types.Message):
             "\U0001F44B Здравствуйте! Нажмите \"Предложить контент\", чтобы отправить материал на модерацию, \"Профиль\" для просмотра статистики или \"Турниры\" для участия."
         )
 
-    await message.answer(text, reply_markup=kb)
+    sent = await message.answer(text, reply_markup=kb)
+    record_sent(sent)

--- a/app/handlers/tournaments.py
+++ b/app/handlers/tournaments.py
@@ -13,6 +13,9 @@ from app.utils import (
     get_tournament_ratings,
     get_tournaments,
     add_participant,
+    record_message,
+    record_sent,
+    cleanup,
 )
 from app.constants import (
     TOURNAMENTS_BUTTON,
@@ -50,24 +53,34 @@ tournament_kb = ReplyKeyboardMarkup(
 @router.message(Command("tournaments"))
 @router.message(F.text == TOURNAMENTS_BUTTON)
 async def tournaments_menu(message: types.Message) -> None:
-    await message.answer(
+    record_message(message)
+    await cleanup(message.bot, message.chat.id)
+    sent = await message.answer(
         "\U0001F3C1 Добро пожаловать в турнирную ЯGAMER. Участвуй и побеждай!",
         reply_markup=tournament_kb,
     )
+    record_sent(sent)
 
 
 @router.message(F.text == BACK_BUTTON)
 async def tournaments_back(message: types.Message) -> None:
-    await message.answer("Главное меню", reply_markup=start.get_menu_kb(message.from_user.id))
+    record_message(message)
+    await cleanup(message.bot, message.chat.id)
+    sent = await message.answer("Главное меню", reply_markup=start.get_menu_kb(message.from_user.id))
+    record_sent(sent)
 
 
 @router.message(F.text == JOIN_BUTTON)
 async def show_tournaments(message: types.Message) -> None:
+    record_message(message)
+    await cleanup(message.bot, message.chat.id)
     tournaments = get_tournaments()
     if not tournaments:
-        await message.answer("\u2753 Турниры не запланированы")
+        sent = await message.answer("\u2753 Турниры не запланированы")
+        record_sent(sent)
         return
-    await message.answer("\U0001F4C5 Актуальные турниры:")
+    sent = await message.answer("\U0001F4C5 Актуальные турниры:")
+    record_sent(sent)
     for tid, game, level, type_, date, prize, preview in tournaments:
         text = f"{tid}. {game} ({level}) {type_} — {date}, призовой фонд: {prize}"
         kb = InlineKeyboardMarkup(
@@ -76,54 +89,71 @@ async def show_tournaments(message: types.Message) -> None:
             ]
         )
         if preview:
-            await message.bot.send_photo(message.chat.id, preview, caption=text, reply_markup=kb)
+            sent_photo = await message.bot.send_photo(message.chat.id, preview, caption=text, reply_markup=kb)
+            record_sent(sent_photo)
         else:
-            await message.answer(text, reply_markup=kb)
+            sent_msg = await message.answer(text, reply_markup=kb)
+            record_sent(sent_msg)
 
 
 @router.message(F.text == RATING_BUTTON)
 async def show_rating(message: types.Message) -> None:
+    record_message(message)
+    await cleanup(message.bot, message.chat.id)
     ratings = get_tournament_ratings()
     if not ratings:
-        await message.answer("\u2753 Рейтинг пока пуст.")
+        sent = await message.answer("\u2753 Рейтинг пока пуст.")
+        record_sent(sent)
         return
 
     lines = ["\U0001F3C6 Рейтинг игроков:"]
     for rank, name, score in ratings:
         lines.append(f"{rank}. {name} — {score}")
-    await message.answer("\n".join(lines))
+    sent = await message.answer("\n".join(lines))
+    record_sent(sent)
 
 
 @router.callback_query(F.data.startswith("join_tour:"))
 async def cb_join_tournament(callback: types.CallbackQuery, state: FSMContext) -> None:
+    await cleanup(callback.bot, callback.message.chat.id)
     tid = int(callback.data.split(":", 1)[1])
     await state.update_data(tid=tid)
     await state.set_state(JoinState.waiting_nick)
-    await callback.message.answer("Введите ваш никнейм", reply_markup=cancel_kb)
+    sent = await callback.message.answer("Введите ваш никнейм", reply_markup=cancel_kb)
+    record_sent(sent)
     await callback.answer()
 
 
 @router.message(JoinState.waiting_nick, F.text == BACK_BUTTON)
 @router.message(JoinState.waiting_age, F.text == BACK_BUTTON)
 async def cancel_join(message: types.Message, state: FSMContext) -> None:
+    record_message(message)
+    await cleanup(message.bot, message.chat.id)
     await state.clear()
-    await message.answer("Главное меню", reply_markup=start.get_menu_kb(message.from_user.id))
+    sent = await message.answer("Главное меню", reply_markup=start.get_menu_kb(message.from_user.id))
+    record_sent(sent)
 
 
 @router.message(JoinState.waiting_nick)
 async def ask_age(message: types.Message, state: FSMContext) -> None:
+    record_message(message)
+    await cleanup(message.bot, message.chat.id)
     await state.update_data(nickname=message.text)
     await state.set_state(JoinState.waiting_age)
-    await message.answer("Введите ваш возраст", reply_markup=cancel_kb)
+    sent = await message.answer("Введите ваш возраст", reply_markup=cancel_kb)
+    record_sent(sent)
 
 
 @router.message(JoinState.waiting_age)
 async def save_participant(message: types.Message, state: FSMContext) -> None:
+    record_message(message)
+    await cleanup(message.bot, message.chat.id)
     data = await state.get_data()
     try:
         age = int(message.text)
     except ValueError:
-        await message.answer("Возраст должен быть числом. Попробуйте снова.")
+        sent = await message.answer("Возраст должен быть числом. Попробуйте снова.")
+        record_sent(sent)
         return
     added = add_participant(
         data.get("tid"),
@@ -132,7 +162,9 @@ async def save_participant(message: types.Message, state: FSMContext) -> None:
         age,
     )
     if added:
-        await message.answer("Вы записаны на турнир!", reply_markup=start.get_menu_kb(message.from_user.id))
+        sent = await message.answer("Вы записаны на турнир!", reply_markup=start.get_menu_kb(message.from_user.id))
+        record_sent(sent)
     else:
-        await message.answer("Вы уже записаны на этот турнир.", reply_markup=start.get_menu_kb(message.from_user.id))
+        sent = await message.answer("Вы уже записаны на этот турнир.", reply_markup=start.get_menu_kb(message.from_user.id))
+        record_sent(sent)
     await state.clear()

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -41,3 +41,5 @@ from .moderation import (
     remove_moderator,
     get_moderators,
 )
+
+from .history import record_message, record_sent, cleanup

--- a/app/utils/history.py
+++ b/app/utils/history.py
@@ -1,0 +1,29 @@
+from collections import defaultdict
+from aiogram import Bot, types
+from aiogram.enums import ChatType
+
+_message_history: dict[int, list[int]] = defaultdict(list)
+
+
+def record_message(message: types.Message) -> None:
+    """Remember a message to remove later."""
+    if message.chat.type != ChatType.PRIVATE:
+        return
+    _message_history[message.chat.id].append(message.message_id)
+
+
+def record_sent(message: types.Message) -> None:
+    """Remember a bot reply to remove later."""
+    if message.chat.type != ChatType.PRIVATE:
+        return
+    _message_history[message.chat.id].append(message.message_id)
+
+
+async def cleanup(bot: Bot, chat_id: int) -> None:
+    """Delete stored messages for chat."""
+    ids = _message_history.pop(chat_id, [])
+    for mid in ids:
+        try:
+            await bot.delete_message(chat_id, mid)
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- add a helper to track and remove messages
- hook cleanup into main user handlers

## Testing
- `python -m compileall -q app bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68894db3e3b883308c818dd0d5ab7d15