### PR TITLE
Add tournament info to signup confirmation

### DIFF
--- a/app/handlers/tournaments.py
+++ b/app/handlers/tournaments.py
@@ -12,6 +12,7 @@ from aiogram.fsm.context import FSMContext
 from app.utils import (
     get_tournament_ratings,
     get_tournaments,
+    get_tournament,
     add_participant,
     record_message,
     record_sent,
@@ -162,7 +163,13 @@ async def save_participant(message: types.Message, state: FSMContext) -> None:
         age,
     )
     if added:
-        sent = await message.answer("Вы записаны на турнир!", reply_markup=start.get_menu_kb(message.from_user.id))
+        tour = get_tournament(data.get("tid"))
+        if tour:
+            _, game, level, type_, date, *_ = tour
+            text = f"Вы записаны на турнир {game} ({level}) {type_} — {date}!"
+        else:
+            text = "Вы записаны на турнир!"
+        sent = await message.answer(text, reply_markup=start.get_menu_kb(message.from_user.id))
         record_sent(sent)
     else:
         sent = await message.answer("Вы уже записаны на этот турнир.", reply_markup=start.get_menu_kb(message.from_user.id))

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -13,6 +13,7 @@ from .database import (
     init_tournament_info_db,
     add_tournament,
     get_tournaments,
+    get_tournament,
     update_tournament,
     delete_tournament,
     add_participant,

--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -233,6 +233,16 @@ def get_tournaments() -> list[tuple]:
         return cur.fetchall()
 
 
+def get_tournament(tid: int) -> tuple | None:
+    """Return tournament information by id."""
+    with sqlite3.connect(TOURNAMENT_INFO_DB_PATH) as conn:
+        cur = conn.execute(
+            "SELECT id, game, level, type, date, prize, preview FROM tournaments WHERE id=?",
+            (tid,),
+        )
+        return cur.fetchone()
+
+
 def update_tournament(
     tid: int, game: str, level: str, type_: str, date: str, prize: str, preview: str | None
 ) -> None:


### PR DESCRIPTION
## Summary
- fetch tournament details by ID
- expose `get_tournament` via utils package
- mention tournament name and date when a user signs up

## Testing
- `python -m py_compile app/handlers/tournaments.py app/utils/database.py app/utils/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_688957eae90c83309f0350bfefcf03f1