### PR TITLE
Add back button after player rating

### DIFF
--- a/app/handlers/tournaments.py
+++ b/app/handlers/tournaments.py
@@ -104,14 +104,16 @@ async def show_rating(message: types.Message) -> None:
     await cleanup(message.bot, message.chat.id)
     ratings = get_tournament_ratings()
     if not ratings:
-        sent = await message.answer("\u2753 Рейтинг пока пуст.")
+        sent = await message.answer(
+            "\u2753 Рейтинг пока пуст.", reply_markup=tournament_kb
+        )
         record_sent(sent)
         return
 
     lines = ["\U0001F3C6 Рейтинг игроков:"]
     for rank, name, score in ratings:
         lines.append(f"{rank}. {name} — {score}")
-    sent = await message.answer("\n".join(lines))
+    sent = await message.answer("\n".join(lines), reply_markup=tournament_kb)
     record_sent(sent)
 
 


### PR DESCRIPTION
## Summary
- return tournament keyboard in rating view so users can go back

## Testing
- `python -m compileall -q app`

------
https://chatgpt.com/codex/tasks/task_e_688d3b06fed48330b3d13fd09bb2a20a