### PR TITLE
Add moderator statistics command and menu button

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -20,6 +20,7 @@ ASSIGN_ROLE_BUTTON = "\U0001F451 Назначить админа/модерат�
 MANAGE_TOURNAMENTS_BUTTON = "\U0001F527 Управление турнирами"
 PARTICIPANTS_LIST_BUTTON = "\U0001F4CB Список участников"
 SEARCH_USER_BUTTON = "\U0001F50E Найти пользователя"
+MOD_STATS_BUTTON = "\U0001F4CA Статистика модерации"
 
 # Skill level options for tournaments
 LEVEL_BEGINNER_BUTTON = "Уровень: Новичок"

--- a/app/handlers/admin.py
+++ b/app/handlers/admin.py
@@ -13,6 +13,7 @@ from app.constants import (
     BANNED_LIST_BUTTON,
     ASSIGN_ROLE_BUTTON,
     SEARCH_USER_BUTTON,
+    MOD_STATS_BUTTON,
     PARTICIPANTS_LIST_BUTTON,
     BACK_BUTTON,
     LEVEL_BEGINNER_BUTTON,
@@ -46,6 +47,7 @@ from app.utils import (
     get_user_stats,
     get_strikes,
     clear_strikes,
+    get_mod_stats,
 )
 
 router = Router()
@@ -190,6 +192,25 @@ async def _send_user_menu(bot: Bot, chat_id: int, user_id: int) -> None:
         f"Титул: {stats.get('title') or '-'}"
     )
     await bot.send_message(chat_id, text, reply_markup=_user_edit_kb(user_id))
+
+
+@router.message(Command("modstats"))
+@router.message(F.text == MOD_STATS_BUTTON)
+async def mod_stats(message: types.Message) -> None:
+    if not _is_staff(message.from_user.id):
+        return
+    stats = get_mod_stats()
+    top = "\n".join(
+        f"{i+1}. {uid} — {count}" for i, (uid, count) in enumerate(stats["top_offenders"])
+    )
+    if not top:
+        top = "нет"
+    text = (
+        f"Предупреждений за сутки: {stats['warnings_24h']}\n"
+        f"Мутов/банов за сутки: {stats['mutes_bans_24h']}\n"
+        f"Топ-нарушителей:\n{top}"
+    )
+    await message.answer(text, reply_markup=_menu_kb(message.from_user.id))
 
 
 @router.message(Command("user"))

--- a/app/handlers/start.py
+++ b/app/handlers/start.py
@@ -14,6 +14,7 @@ from app.constants import (
     MUTED_LIST_BUTTON,
     BANNED_LIST_BUTTON,
     ASSIGN_ROLE_BUTTON,
+    MOD_STATS_BUTTON,
 )
 from app.utils import (
     add_user,
@@ -64,6 +65,7 @@ admin_kb = ReplyKeyboardMarkup(
         [KeyboardButton(text=MANAGE_TOURNAMENTS_BUTTON)],
         [KeyboardButton(text=MUTED_LIST_BUTTON), KeyboardButton(text=BANNED_LIST_BUTTON)],
         [KeyboardButton(text=SEARCH_USER_BUTTON)],
+        [KeyboardButton(text=MOD_STATS_BUTTON)],
     ],
     resize_keyboard=True,
 )
@@ -71,6 +73,7 @@ admin_kb = ReplyKeyboardMarkup(
 moderator_kb = ReplyKeyboardMarkup(
     keyboard=[
         [KeyboardButton(text=MUTED_LIST_BUTTON), KeyboardButton(text=BANNED_LIST_BUTTON)],
+        [KeyboardButton(text=MOD_STATS_BUTTON)],
     ],
     resize_keyboard=True,
 )
@@ -82,6 +85,7 @@ main_admin_kb = ReplyKeyboardMarkup(
         [KeyboardButton(text=MUTED_LIST_BUTTON), KeyboardButton(text=BANNED_LIST_BUTTON)],
         [KeyboardButton(text=ASSIGN_ROLE_BUTTON)],
         [KeyboardButton(text=SEARCH_USER_BUTTON)],
+        [KeyboardButton(text=MOD_STATS_BUTTON)],
     ],
     resize_keyboard=True,
 )

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -48,6 +48,7 @@ from .modlog import (
     add_strike,
     get_strikes,
     clear_strikes,
+    get_mod_stats,
 )
 
 from .history import record_message, record_sent, cleanup


### PR DESCRIPTION
## Summary
- Add constant and menu buttons for moderator statistics
- Implement `/modstats` command to report warnings, mutes/bans, and top offenders
- Provide utility to query moderation logs for stats

## Testing
- `python -m py_compile app/constants.py app/handlers/start.py app/handlers/admin.py app/utils/modlog.py app/utils/__init__.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892804b704483308141304b6ad4395a