### PR TITLE
Show usernames in modstats top offenders

### DIFF
--- a/app/handlers/admin.py
+++ b/app/handlers/admin.py
@@ -200,9 +200,13 @@ async def mod_stats(message: types.Message) -> None:
     if not _is_staff(message.from_user.id):
         return
     stats = get_mod_stats()
-    top = "\n".join(
-        f"{i+1}. {uid} — {count}" for i, (uid, count) in enumerate(stats["top_offenders"])
-    )
+    top_lines = []
+    for i, (uid, count) in enumerate(stats["top_offenders"]):
+        user_stats = get_user_stats(uid) or {}
+        top_lines.append(
+            f"{i+1}. {uid} (@{user_stats.get('username') or 'нет'}) — {count}"
+        )
+    top = "\n".join(top_lines)
     if not top:
         top = "нет"
     text = (


### PR DESCRIPTION
## Summary
- Include @username alongside user ID in /modstats top offenders list

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689283b437488330bec4e62a59361b35